### PR TITLE
Fix Reference Spacing

### DIFF
--- a/xsl/mathbook-jupyter.xsl
+++ b/xsl/mathbook-jupyter.xsl
@@ -633,7 +633,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="*" mode="xref-link">
     <xsl:param name="content" />
     <!-- text in square brackets -->
-    <xsl:text>[</xsl:text>
+    <xsl:text> [</xsl:text>
     <xsl:value-of select="$content" />
     <xsl:text>]</xsl:text>
     <!-- url in parentheses -->


### PR DESCRIPTION
The spacing in Jupyter output currently is lacking a space in
references of the form "Example 3.14.1", causing the reference to
appear as "Example3.14.1", this adds the space to render properly